### PR TITLE
reload db on update fn

### DIFF
--- a/src/components/coordinator/manageActivePowerTable.tsx
+++ b/src/components/coordinator/manageActivePowerTable.tsx
@@ -68,6 +68,7 @@ export function ManageActivePowerTable(): JSX.Element {
     } else {
       toast.error(data.message);
     }
+    setReload(!reload);
     return newRow;
   }
 


### PR DESCRIPTION
There was an issue where it seemed like data was saving in the DB in the manage active power table.

The problem was the update function was not reloading the component after it ran.

Now, we toggle reload, so after the update function runs, we query the DB and render what is stored there. This means if it succeeds, it will pull the new data, and if it fails it will pull the old data.