### PR TITLE
Show updated pollResults when you end a poll

### DIFF
--- a/src/components/buttons/endVoteButton.tsx
+++ b/src/components/buttons/endVoteButton.tsx
@@ -3,19 +3,38 @@ import { useSession } from 'next-auth/react';
 import toast from 'react-hot-toast';
 
 import { endVoting } from '@/lib/helpers/endVoting';
+import { getPollResults } from '@/lib/helpers/getPollResults';
 
 interface Props {
   pollId: string | string[] | undefined;
   isSubmitting: boolean;
   setIsSubmitting: (value: boolean) => void;
+  updatePollResults: (newPollResults: {
+    yes: {
+      name: string;
+      id: string;
+    }[];
+    no: {
+      name: string;
+      id: string;
+    }[];
+    abstain: {
+      name: string;
+      id: string;
+    }[];
+  }) => void;
 }
 
 /**
  * A button for workshop coordinators to end voting for a poll
+ * @param pollId - The pollId of the poll to end voting for
+ * @param isSubmitting - Whether the button is in a submitting state
+ * @param setIsSubmitting - Function to set the submitting state
+ * @param updatePollResults - Function to update the poll results after voting ends
  * @returns End Voting Button
  */
 export function EndVoteButton(props: Props): JSX.Element {
-  const { pollId, isSubmitting, setIsSubmitting } = props;
+  const { pollId, isSubmitting, setIsSubmitting, updatePollResults } = props;
 
   const session = useSession();
 
@@ -30,6 +49,12 @@ export function EndVoteButton(props: Props): JSX.Element {
     if (result.succeeded === false) {
       toast.error(result.message);
     } else {
+      const pollResults = await getPollResults(pollId);
+      if (!pollResults.votes) {
+        toast.error('Error fetching poll results');
+      } else {
+        updatePollResults(pollResults.votes);
+      }
       toast.success('Voting ended!');
     }
     setIsSubmitting(false);

--- a/src/pages/polls/[pollId]/index.tsx
+++ b/src/pages/polls/[pollId]/index.tsx
@@ -34,7 +34,7 @@ interface Props {
   poll: Poll | null;
   representatives: User[];
   workshops: Workshop[];
-  pollResults: {
+  pollResultsSSR: {
     yes: {
       name: string;
       id: string;
@@ -52,9 +52,10 @@ interface Props {
 }
 
 export default function ViewPoll(props: Props): JSX.Element {
-  const { representatives, workshops, pollResults, polls } = props;
+  const { representatives, workshops, pollResultsSSR, polls } = props;
   let { poll } = props;
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [pollResults, setPollResults] = useState(pollResultsSSR);
 
   const session = useSession();
   const router = useRouter();
@@ -76,6 +77,26 @@ export default function ViewPoll(props: Props): JSX.Element {
   const updateIsSubmitting = useCallback((value: boolean) => {
     setIsSubmitting(value);
   }, []);
+
+  const updatePollResults = useCallback(
+    (newPollResults: {
+      yes: {
+        name: string;
+        id: string;
+      }[];
+      no: {
+        name: string;
+        id: string;
+      }[];
+      abstain: {
+        name: string;
+        id: string;
+      }[];
+    }) => {
+      setPollResults(newPollResults);
+    },
+    [],
+  );
 
   if (data && data.poll) {
     poll = data.poll;
@@ -167,6 +188,7 @@ export default function ViewPoll(props: Props): JSX.Element {
                               pollId={pollId}
                               isSubmitting={isSubmitting}
                               setIsSubmitting={updateIsSubmitting}
+                              updatePollResults={updatePollResults}
                             />
                           )}
                           <DeletePollButton
@@ -226,7 +248,7 @@ export const getServerSideProps = async (
     poll: Poll | null;
     representatives: User[];
     workshops: Workshop[];
-    pollResults: {
+    pollResultsSSR: {
       [key: string]: {
         name: string;
         id: string;
@@ -241,7 +263,7 @@ export const getServerSideProps = async (
         poll: null,
         representatives: [],
         workshops: [],
-        pollResults: {},
+        pollResultsSSR: {},
         polls: [],
       },
     };
@@ -252,7 +274,7 @@ export const getServerSideProps = async (
   const poll = await pollDto(pollId);
   const representatives = await representativesDto();
   const workshops = await workshopsDto();
-  const pollResults = await pollResultsDto(pollId);
+  const pollResultsSSR = await pollResultsDto(pollId);
   const polls = await pollsDto();
 
   return {
@@ -260,7 +282,7 @@ export const getServerSideProps = async (
       poll: poll,
       representatives: representatives,
       workshops: workshops,
-      pollResults: pollResults,
+      pollResultsSSR: pollResultsSSR,
       polls: polls,
     },
   };


### PR DESCRIPTION
There was an issue where after ending a poll, it would just show 0 votes. You had to update the page to get the actual poll results.

Now the finalized poll results are shown when a poll ends.

### Before

https://github.com/user-attachments/assets/042680dc-2458-4956-9e19-fc6c3ffa38d1

### After

https://github.com/user-attachments/assets/33e73f2b-558c-47c8-bf7f-8014f9fa471d
