### PR TITLE
Fix not active voter flashing

### DIFF
--- a/src/components/buttons/voteOnPollButtons.tsx
+++ b/src/components/buttons/voteOnPollButtons.tsx
@@ -9,23 +9,26 @@ import { useSession } from 'next-auth/react';
 import toast from 'react-hot-toast';
 
 import { castVote } from '@/lib/helpers/castVote';
-import { getActiveVoterFromUserId } from '@/lib/helpers/getActiveVoterFromUserId';
 import { getPollVote } from '@/lib/helpers/getPollVote';
 
 interface Props {
   pollId: string;
   disabled: boolean;
   setDisabled: (value: boolean) => void;
+  isActiveVoter: boolean;
 }
 
 /**
  * Yes, No, Abstain buttons to vote on a poll
+ * @param pollId - The ID of the poll
+ * @param disabled - Whether the buttons are disabled
+ * @param setDisabled - Function to set the disabled state
+ * @param isActiveVoter - Whether the user is the active voter
  * @returns Vote on Poll Buttons
  */
 export function VoteOnPollButtons(props: Props): JSX.Element {
-  const { pollId, disabled, setDisabled } = props;
+  const { pollId, disabled, setDisabled, isActiveVoter } = props;
   const [vote, setVote] = useState('');
-  const [activeVoter, setActiveVoter] = useState('');
 
   const session = useSession();
   const theme = useTheme();
@@ -59,21 +62,6 @@ export function VoteOnPollButtons(props: Props): JSX.Element {
       getVote();
     }
   }, [session.data?.user.id, pollId, disabled]);
-
-  // get the active voter from this workshop
-  useEffect(() => {
-    async function getActiveVoter(): Promise<void> {
-      if (session.data?.user.id) {
-        const activeVoter = await getActiveVoterFromUserId(
-          session.data?.user.id,
-        );
-        setActiveVoter(activeVoter.activeVoterId);
-      }
-    }
-    getActiveVoter();
-  }, [pollId]);
-
-  const isActiveVoter = activeVoter === session.data?.user.id;
 
   return (
     <>

--- a/src/data/activeVoterDto.ts
+++ b/src/data/activeVoterDto.ts
@@ -1,0 +1,25 @@
+import { prisma } from '@/db';
+
+import { convertBigIntsToStrings } from '@/lib/convertBigIntsToStrings';
+
+/**
+ * Gets the active voter for a workshop of the signed-in user
+ * @param userId - The ID of the current user
+ * @returns Formatted active voter ID for a workshop
+ */
+export async function activeVoterDto(userId: string): Promise<string | null> {
+  const user = await prisma.user.findUnique({
+    where: { id: BigInt(userId) },
+    include: {
+      workshop_user_workshop_idToworkshop: true,
+    },
+  });
+
+  if (!user) {
+    return null;
+  }
+
+  const formattedUser = convertBigIntsToStrings(user);
+
+  return formattedUser.workshop_user_workshop_idToworkshop.active_voter_id;
+}


### PR DESCRIPTION
There was an issue where the UI would initially tell any user they are not the active voter even if they actually are the active voter. The active voter check has been moved to SSR so this inaccurate flashing will no longer occur.