### PR TITLE
Hide Active Vote Data

### DIFF
--- a/src/data/pollVotesDto.ts
+++ b/src/data/pollVotesDto.ts
@@ -29,6 +29,9 @@ export async function pollVotesDto(pollId: string): Promise<
   const pollVotes = await prisma.poll_vote.findMany({
     where: {
       poll_id: BigInt(pollId),
+      poll: {
+        status: 'concluded',
+      },
     },
     include: {
       poll_transaction: {


### PR DESCRIPTION
only select poll votes where the poll is concluded for pollVotesDto, used in downloading results

there was already a check for this where this helper would only get called by an api that already checked if it was concluded, but this additional check won't hurt.