### PR TITLE
Add stake address to delegate's page

### DIFF
--- a/__tests__/pages/representatives/[userId]/showsRepresentativeInformationOnViewRepresentativesPage.test.tsx
+++ b/__tests__/pages/representatives/[userId]/showsRepresentativeInformationOnViewRepresentativesPage.test.tsx
@@ -12,13 +12,34 @@ test('Shows Representative information on view representative page', async () =>
           id: '1',
           stakeAddress: 'stakeAddress',
           walletName: 'walletName',
+          isCoordinator: false,
+          isDelegate: true,
+          isAlternate: false,
         },
       }}
     >
-      <Representative />
+      <Representative
+        user={{
+          id: '1',
+          is_convention_organizer: false,
+          is_delegate: true,
+          is_alternate: false,
+          workshop_id: '1',
+          name: 'Test User',
+          email: 'email@email.com',
+          wallet_address: 'stake1234',
+        }}
+        userVotes={[]} // Not important for this test
+        representatives={[]} // Not important for this test
+        workshops={[]} // Not important for this test
+        workshopName="Austin, TX" // Not important for this test
+        polls={[]} // Not important for this test
+        isActiveVoter={true} // Not important for this test
+      />
     </SessionProvider>,
   );
-  expect(await screen.findAllByText('John Johnson')).toBeDefined();
+  expect(await screen.findAllByText('Test User')).toBeDefined();
   expect(await screen.findAllByText('Delegate')).toBeDefined();
   expect(await screen.findAllByText('Austin, TX')).toBeDefined();
+  expect(await screen.findByText('stake1234')).toBeDefined();
 });

--- a/src/pages/representatives/[userId]/index.tsx
+++ b/src/pages/representatives/[userId]/index.tsx
@@ -76,6 +76,18 @@ export default function Representative(props: Props): JSX.Element {
                   >
                     {user.name}
                   </Typography>
+                  <Typography
+                    variant="h6"
+                    fontWeight="bold"
+                    data-testid="user-wallet-address"
+                    sx={{
+                      wordWrap: 'break-word', // Break long words
+                      overflowWrap: 'break-word', // Ensures wrapping works on all browsers
+                      whiteSpace: 'normal', // Allows text to wrap
+                    }}
+                  >
+                    {user.wallet_address}
+                  </Typography>
                   <Box display="flex" flexDirection="row" gap={1}>
                     <Box sx={{ color: theme.palette.text.disabled }}>
                       {isActiveVoter === true ? (


### PR DESCRIPTION
Adds a delegate's stake address to their representative page so that they can verify it is correct prior to the convention.

Desktop:
![Screenshot 2024-11-20 at 9 47 18 AM](https://github.com/user-attachments/assets/d2d92d73-e06a-411a-b64d-51cc49e9c410)

Mobile:
![Screenshot 2024-11-20 at 9 47 29 AM](https://github.com/user-attachments/assets/057558a1-8ab0-492b-9de0-e8bf252e8825)
