### PR TITLE
Fix testnet login

### DIFF
--- a/src/lib/deriveStakeAddressFromPublicKey.ts
+++ b/src/lib/deriveStakeAddressFromPublicKey.ts
@@ -16,8 +16,8 @@ export function deriveStakeAddressFromPublicKey(publicKey: PublicKey): string {
   // Create a StakeCredential using the stake key hash
   const stakeCredential = Credential.from_keyhash(stakeKeyHash);
 
-  // Generate the stake address (e.g., for mainnet)
-  const networkId = 1; // 1 for mainnet, 0 for testnet
+  // Generate the stake address
+  const networkId = process.env.NEXT_PUBLIC_NETWORK === 'mainnet' ? 1 : 0; // 1 for mainnet, 0 for testnet
   const stakeAddress = RewardAddress.new(
     networkId,
     stakeCredential,


### PR DESCRIPTION
When I added verifying stake address to `verifyWallet`, it was hardcoded to mainnet. This PR fixes that.