### PR TITLE
Increase metadata size limit to 13kb

### DIFF
--- a/src/pages/api/getVotesTxMetadata/[pollId].ts
+++ b/src/pages/api/getVotesTxMetadata/[pollId].ts
@@ -92,7 +92,7 @@ export default async function getVotesTxMetadata(
       const bytes = getBytesOfArray(temporaryMetadataArray);
       // Limit is set to 10 KB right now. Cardano TX limit is 16KB. This is to be safe. If the limit is reached, create a new entry in the metadata object.
       // Not entirely sure what the limit should be. However, I would rather the CO have to sign multiple transactions than have the TX building fail.
-      if (bytes > 10000) {
+      if (bytes > 13000) {
         metadata[i] = {
           metadata: temporaryMetadataArray,
           userIds: temporaryUserArray,


### PR DESCRIPTION
With the previous limit of 10kb we could fit 13 votes per TX. That means we could only fit 13 votes per TX so the CO had to sign a total of 6 TXs (this includes the summary TX).

I have increased the limit to 13kb so we can fit 17 votes per TX. This means the CO now only has to sign a total of 5 TXs (this includes the summary TX).

I ran through 2 E2E tests with 63 mock votes and all of the TXs worked fine.

As can be seen in the screenshot below, we are still well below the 16kb TX size limit.
![Screenshot 2024-11-22 at 12 02 37 PM](https://github.com/user-attachments/assets/6b140020-c952-44c2-8e14-9fcb5379bab9)

**Note:** Due to addition of more text in PR #163, the above numbers may not be completely accurate.