### PR TITLE
Remove duplicate check address intervals

### DIFF
--- a/src/hooks/useCheckAddressChange.tsx
+++ b/src/hooks/useCheckAddressChange.tsx
@@ -5,6 +5,8 @@ import { signOut, useSession } from 'next-auth/react';
 
 import { checkAddressChange } from '@/lib/checkAddressChange';
 
+let globalIntervalRef: NodeJS.Timeout | null = null;
+
 /**
  * This hook checks if the user has changed their wallet since connecting.
  * If the user has changed their wallet, it will sign them out.
@@ -34,11 +36,20 @@ export function useCheckAddressChange(): void {
         }
       }
 
-      // Run the function every second
-      const intervalId = setInterval(handler, 1000);
+      if (globalIntervalRef) {
+        // Clear existing interval if one exists
+        clearInterval(globalIntervalRef);
+      }
+      // Run the function every 3 seconds
+      globalIntervalRef = setInterval(handler, 3000);
 
-      // Cleanup interval on unmount
-      return (): void => clearInterval(intervalId);
+      // Cleanup the interval when the component unmounts
+      return (): void => {
+        if (globalIntervalRef) {
+          clearInterval(globalIntervalRef);
+          globalIntervalRef = null;
+        }
+      };
     }
   }, [session, wallet, updateWallet]);
 }


### PR DESCRIPTION
This morning Thomas mentioned he was sometimes getting signed out after a period of inactivity. I actually noticed that as well. I believe the issue was related to the `useCheckAddressChange` hook.

The `useCheckAddressChange` hook checks every second for if a wallet's account has changed. If so, it logs out the user and redirects them to the homepage. However, it would create a new interval everytime the user navigated to a new page. I believe these multiple intervals were conflicting with each other.

Now the hook will only create 1 instance of the interval. I also changed the interval to every 3 seconds instead of every 1 second.