### PR TITLE
add hash on poll id page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "cardano-constitution-voting-app",
       "version": "0.1.0",
       "hasInstallScript": true,
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@claritydao/clarity-backend": "^0.4.0-dev-512cc333547522c7d53ffe0ecddacd3de3958dd1",
         "@emotion/react": "^11.13.3",

--- a/src/pages/polls/[pollId]/index.tsx
+++ b/src/pages/polls/[pollId]/index.tsx
@@ -202,7 +202,13 @@ export default function ViewPoll(props: Props): JSX.Element {
                   </Button>
                 </Box>
 
-                <Typography>
+                <Typography
+                  sx={{
+                    wordWrap: 'break-word', // Break long words
+                    overflowWrap: 'break-word', // Ensures wrapping works on all browsers
+                    whiteSpace: 'normal', // Allows text to wrap
+                  }}
+                >
                   The linked text document has the Blake2b-256 hash of:{' '}
                   {poll.hashedText}
                 </Typography>

--- a/src/pages/polls/[pollId]/index.tsx
+++ b/src/pages/polls/[pollId]/index.tsx
@@ -185,15 +185,27 @@ export default function ViewPoll(props: Props): JSX.Element {
           <PollVoteCount pollId={poll?.id || ''} />
           <Grid container data-testid="poll-transactions">
             {poll ? (
-              <Grid size={{ xs: 12, lg: 6 }}>
-                <Button
-                  variant="outlined"
-                  href={poll.link}
-                  target="_blank"
-                  startIcon={<LaunchRounded />}
-                >
-                  <Typography>View Constitution Text</Typography>
-                </Button>
+              <Grid
+                size={{ xs: 12, lg: 6 }}
+                display="flex"
+                flexDirection="column"
+                gap={3}
+              >
+                <Box>
+                  <Button
+                    variant="outlined"
+                    href={poll.link}
+                    target="_blank"
+                    startIcon={<LaunchRounded />}
+                  >
+                    <Typography>View Constitution Text</Typography>
+                  </Button>
+                </Box>
+
+                <Typography>
+                  The linked text document has the Blake2b-256 hash of:{' '}
+                  {poll.hashedText}
+                </Typography>
                 {poll.summary_tx_id && !isTxUploading && (
                   <Box marginTop={3} marginBottom={3}>
                     <ViewTxButton txId={poll.summary_tx_id} />


### PR DESCRIPTION
Show poll hash on poll id page.

![image](https://github.com/user-attachments/assets/4ce079d1-9a78-4409-bf50-9dae9602cdf4)

closes #147 
