### PR TITLE
add fallback background color

### DIFF
--- a/src/providers/themeProvider.tsx
+++ b/src/providers/themeProvider.tsx
@@ -244,6 +244,7 @@ export function ColorModeProvider({
     <>
       <Box
         sx={{
+          background: 'rgb(13,26,61)',
           backgroundImage: `url(${gradient.src})`,
           backgroundRepeat: 'no-repeat',
           backgroundSize: 'cover',


### PR DESCRIPTION
Adds a blue fallback color to the app that's replaced by the background image once it loads. In areas where there's weak internet connection, sometimes the app could load slowly with no background, and you couldn't see the white text against the white background. This gives the users a way to see the content while the background is loading in this case.