### PR TITLE
Not active voter fix

### DIFF
--- a/__tests__/components/buttons/voteOnPollButton/alertsUserWhenPollHasFinishedVoting.test.tsx
+++ b/__tests__/components/buttons/voteOnPollButton/alertsUserWhenPollHasFinishedVoting.test.tsx
@@ -19,6 +19,9 @@ test.skip('alerts user when poll has finished voting', async () => {
           id: '1',
           stakeAddress: 'stakeAddress',
           walletName: 'walletName',
+          isCoordinator: false,
+          isDelegate: true,
+          isAlternate: false,
         },
       }}
     >
@@ -26,7 +29,6 @@ test.skip('alerts user when poll has finished voting', async () => {
       <VoteOnPollButtons
         pollName="Test Poll"
         pollId="1"
-        isActiveVoter={true}
         hashedText="1dda86a28da3715e618a1605f81c7a3121ce767cdc9bd0d46beec0bef40e8125"
         link="https://www.intersectmbo.org/constitution/constitution.html"
       />

--- a/__tests__/components/buttons/voteOnPollButton/alertsUserWhenPollIdIsNotProvided.test.tsx
+++ b/__tests__/components/buttons/voteOnPollButton/alertsUserWhenPollIdIsNotProvided.test.tsx
@@ -19,6 +19,9 @@ test.skip('alerts user when poll ID is not provided', async () => {
           id: '1',
           stakeAddress: 'stakeAddress',
           walletName: 'walletName',
+          isCoordinator: false,
+          isDelegate: true,
+          isAlternate: false,
         },
       }}
     >
@@ -26,7 +29,6 @@ test.skip('alerts user when poll ID is not provided', async () => {
       <VoteOnPollButtons
         pollName="Test Poll"
         pollId="1"
-        isActiveVoter={true}
         hashedText="1dda86a28da3715e618a1605f81c7a3121ce767cdc9bd0d46beec0bef40e8125"
         link="https://www.intersectmbo.org/constitution/constitution.html"
       />

--- a/__tests__/components/buttons/voteOnPollButton/alertsUserWhenPollIsArchived.test.tsx
+++ b/__tests__/components/buttons/voteOnPollButton/alertsUserWhenPollIsArchived.test.tsx
@@ -19,6 +19,9 @@ test.skip('alerts user when poll is archived', async () => {
           id: '1',
           stakeAddress: 'stakeAddress',
           walletName: 'walletName',
+          isCoordinator: false,
+          isDelegate: true,
+          isAlternate: false,
         },
       }}
     >
@@ -26,7 +29,6 @@ test.skip('alerts user when poll is archived', async () => {
       <VoteOnPollButtons
         pollName="Test Poll"
         pollId="1"
-        isActiveVoter={true}
         hashedText="1dda86a28da3715e618a1605f81c7a3121ce767cdc9bd0d46beec0bef40e8125"
         link="https://www.intersectmbo.org/constitution/constitution.html"
       />

--- a/__tests__/components/buttons/voteOnPollButton/alertsUserWhenPollIsNotFound.test.tsx
+++ b/__tests__/components/buttons/voteOnPollButton/alertsUserWhenPollIsNotFound.test.tsx
@@ -19,6 +19,9 @@ test.skip('alerts user when poll is not found', async () => {
           id: '1',
           stakeAddress: 'stakeAddress',
           walletName: 'walletName',
+          isCoordinator: false,
+          isDelegate: true,
+          isAlternate: false,
         },
       }}
     >
@@ -26,7 +29,6 @@ test.skip('alerts user when poll is not found', async () => {
       <VoteOnPollButtons
         pollName="Test Poll"
         pollId="1"
-        isActiveVoter={true}
         hashedText="1dda86a28da3715e618a1605f81c7a3121ce767cdc9bd0d46beec0bef40e8125"
         link="https://www.intersectmbo.org/constitution/constitution.html"
       />

--- a/__tests__/components/buttons/voteOnPollButton/alertsUserWhenPollIsNotOpenForVotingYet.test.tsx
+++ b/__tests__/components/buttons/voteOnPollButton/alertsUserWhenPollIsNotOpenForVotingYet.test.tsx
@@ -19,6 +19,9 @@ test.skip('alerts user when poll is not open for voting yet', async () => {
           id: '1',
           stakeAddress: 'stakeAddress',
           walletName: 'walletName',
+          isCoordinator: false,
+          isDelegate: true,
+          isAlternate: false,
         },
       }}
     >
@@ -26,7 +29,6 @@ test.skip('alerts user when poll is not open for voting yet', async () => {
       <VoteOnPollButtons
         pollName="Test Poll"
         pollId="1"
-        isActiveVoter={true}
         hashedText="1dda86a28da3715e618a1605f81c7a3121ce767cdc9bd0d46beec0bef40e8125"
         link="https://www.intersectmbo.org/constitution/constitution.html"
       />

--- a/__tests__/components/buttons/voteOnPollButton/alertsUserWhenVoteFailsToCast.test.tsx
+++ b/__tests__/components/buttons/voteOnPollButton/alertsUserWhenVoteFailsToCast.test.tsx
@@ -19,6 +19,9 @@ test.skip('alerts user when poll has finished voting', async () => {
           id: '1',
           stakeAddress: 'stakeAddress',
           walletName: 'walletName',
+          isCoordinator: false,
+          isDelegate: true,
+          isAlternate: false,
         },
       }}
     >
@@ -26,7 +29,6 @@ test.skip('alerts user when poll has finished voting', async () => {
       <VoteOnPollButtons
         pollName="Test Poll"
         pollId="1"
-        isActiveVoter={true}
         hashedText="1dda86a28da3715e618a1605f81c7a3121ce767cdc9bd0d46beec0bef40e8125"
         link="https://www.intersectmbo.org/constitution/constitution.html"
       />

--- a/__tests__/components/buttons/voteOnPollButton/alertsUserWhenVoteIsInvalid.test.tsx
+++ b/__tests__/components/buttons/voteOnPollButton/alertsUserWhenVoteIsInvalid.test.tsx
@@ -19,6 +19,9 @@ test.skip('alerts user when vote is invalid', async () => {
           id: '1',
           stakeAddress: 'stakeAddress',
           walletName: 'walletName',
+          isCoordinator: false,
+          isDelegate: true,
+          isAlternate: false,
         },
       }}
     >
@@ -26,7 +29,6 @@ test.skip('alerts user when vote is invalid', async () => {
       <VoteOnPollButtons
         pollName="Test Poll"
         pollId="1"
-        isActiveVoter={true}
         hashedText="1dda86a28da3715e618a1605f81c7a3121ce767cdc9bd0d46beec0bef40e8125"
         link="https://www.intersectmbo.org/constitution/constitution.html"
       />

--- a/__tests__/components/buttons/voteOnPollButton/alertsUserWhenVoteIsNotProvided.test.tsx
+++ b/__tests__/components/buttons/voteOnPollButton/alertsUserWhenVoteIsNotProvided.test.tsx
@@ -19,6 +19,9 @@ test.skip('alerts user when vote is not provided', async () => {
           id: '1',
           stakeAddress: 'stakeAddress',
           walletName: 'walletName',
+          isCoordinator: false,
+          isDelegate: true,
+          isAlternate: false,
         },
       }}
     >
@@ -26,7 +29,6 @@ test.skip('alerts user when vote is not provided', async () => {
       <VoteOnPollButtons
         pollName="Test Poll"
         pollId="1"
-        isActiveVoter={true}
         hashedText="1dda86a28da3715e618a1605f81c7a3121ce767cdc9bd0d46beec0bef40e8125"
         link="https://www.intersectmbo.org/constitution/constitution.html"
       />

--- a/__tests__/components/buttons/voteOnPollButton/successfullyVotesAbstainOnAPoll.test.tsx
+++ b/__tests__/components/buttons/voteOnPollButton/successfullyVotesAbstainOnAPoll.test.tsx
@@ -16,6 +16,9 @@ test.skip('successfully votes abstain on a poll', async () => {
           id: '1',
           stakeAddress: 'stakeAddress',
           walletName: 'walletName',
+          isCoordinator: false,
+          isDelegate: true,
+          isAlternate: false,
         },
       }}
     >
@@ -23,7 +26,6 @@ test.skip('successfully votes abstain on a poll', async () => {
       <VoteOnPollButtons
         pollName="Test Poll"
         pollId="1"
-        isActiveVoter={true}
         hashedText="1dda86a28da3715e618a1605f81c7a3121ce767cdc9bd0d46beec0bef40e8125"
         link="https://www.intersectmbo.org/constitution/constitution.html"
       />

--- a/__tests__/components/buttons/voteOnPollButton/successfullyVotesNoAPoll.test.tsx
+++ b/__tests__/components/buttons/voteOnPollButton/successfullyVotesNoAPoll.test.tsx
@@ -16,6 +16,9 @@ test.skip('successfully votes no on a poll', async () => {
           id: '1',
           stakeAddress: 'stakeAddress',
           walletName: 'walletName',
+          isCoordinator: false,
+          isDelegate: true,
+          isAlternate: false,
         },
       }}
     >
@@ -23,7 +26,6 @@ test.skip('successfully votes no on a poll', async () => {
       <VoteOnPollButtons
         pollName="Test Poll"
         pollId="1"
-        isActiveVoter={true}
         hashedText="1dda86a28da3715e618a1605f81c7a3121ce767cdc9bd0d46beec0bef40e8125"
         link="https://www.intersectmbo.org/constitution/constitution.html"
       />

--- a/__tests__/components/buttons/voteOnPollButton/successfullyVotesYesOnAPoll.test.tsx
+++ b/__tests__/components/buttons/voteOnPollButton/successfullyVotesYesOnAPoll.test.tsx
@@ -16,6 +16,9 @@ test.skip('successfully votes yes on a poll', async () => {
           id: '1',
           stakeAddress: 'stakeAddress',
           walletName: 'walletName',
+          isCoordinator: false,
+          isDelegate: true,
+          isAlternate: false,
         },
       }}
     >
@@ -23,7 +26,6 @@ test.skip('successfully votes yes on a poll', async () => {
       <VoteOnPollButtons
         pollName="Test Poll"
         pollId="1"
-        isActiveVoter={true}
         hashedText="1dda86a28da3715e618a1605f81c7a3121ce767cdc9bd0d46beec0bef40e8125"
         link="https://www.intersectmbo.org/constitution/constitution.html"
       />

--- a/src/components/buttons/voteOnPollButtons.tsx
+++ b/src/components/buttons/voteOnPollButtons.tsx
@@ -9,12 +9,12 @@ import { useSession } from 'next-auth/react';
 import toast from 'react-hot-toast';
 
 import { castVote } from '@/lib/helpers/castVote';
+import { getActiveVoterFromUserId } from '@/lib/helpers/getActiveVoterFromUserId';
 import { getPollVote } from '@/lib/helpers/getPollVote';
 
 interface Props {
   pollName: string;
   pollId: string;
-  isActiveVoter: boolean;
   hashedText: string;
   link: string;
 }
@@ -23,16 +23,32 @@ interface Props {
  * Yes, No, Abstain buttons to vote on a poll
  * @param pollName - The name of the poll
  * @param pollId - The ID of the poll
- * @param isActiveVoter - Whether the user is the active voter
+ * @param hashedText - The hashed text of the poll
+ * @param link - The link to the poll
  * @returns Vote on Poll Buttons
  */
 export function VoteOnPollButtons(props: Props): JSX.Element {
-  const { pollName, pollId, isActiveVoter, hashedText, link } = props;
-  const [vote, setVote] = useState('');
-  const [disabled, setDisabled] = useState(false);
+  const { pollName, pollId, hashedText, link } = props;
 
   const session = useSession();
   const theme = useTheme();
+
+  const [vote, setVote] = useState('');
+  const [disabled, setDisabled] = useState(false);
+  const [isActiveVoter, setIsActiveVoter] = useState(false);
+  const [fetching, setIsFetching] = useState(
+    session.status === 'authenticated' ? false : true,
+  );
+
+  useEffect(() => {
+    if (session.data?.user.id) {
+      setIsFetching(true);
+      getActiveVoterFromUserId(session.data.user.id).then((result) => {
+        setIsActiveVoter(result.activeVoterId === session.data.user.id);
+        setIsFetching(false);
+      });
+    }
+  }, [session.data?.user.id]);
 
   async function handleVote(vote: string): Promise<void> {
     setDisabled(true);
@@ -91,7 +107,7 @@ export function VoteOnPollButtons(props: Props): JSX.Element {
               </Typography>
             </Box>
           )}
-          {!isActiveVoter && !session.data?.user.isCoordinator && (
+          {!isActiveVoter && !session.data?.user.isCoordinator && !fetching && (
             <Typography variant="h6" fontWeight="bold">
               You are not the active voter for your workshop. Only the active
               voter can vote.

--- a/src/pages/polls/[pollId]/index.tsx
+++ b/src/pages/polls/[pollId]/index.tsx
@@ -4,19 +4,16 @@ import type { GetServerSidePropsContext } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { pollPhases } from '@/constants/pollPhases';
-import { authOptions } from '@/pages/api/auth/[...nextauth]';
 import LaunchRounded from '@mui/icons-material/LaunchRounded';
 import { Button, CircularProgress, Modal, useTheme } from '@mui/material';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid2';
 import Typography from '@mui/material/Typography';
 import { useQuery } from '@tanstack/react-query';
-import { getServerSession } from 'next-auth';
 import { useSession } from 'next-auth/react';
 import toast from 'react-hot-toast';
 
 import type { Poll, User, Workshop } from '@/types';
-import { activeVoterDto } from '@/data/activeVoterDto';
 import { pollDto } from '@/data/pollDto';
 import { pollResultsDto } from '@/data/pollResultsDto';
 import { pollsDto } from '@/data/pollsDto';
@@ -58,17 +55,10 @@ interface Props {
     }[];
   };
   polls: Poll[];
-  workshopActiveVoterId: string;
 }
 
 export default function ViewPoll(props: Props): JSX.Element {
-  const {
-    representatives,
-    workshops,
-    pollResultsSSR,
-    polls,
-    workshopActiveVoterId,
-  } = props;
+  const { representatives, workshops, pollResultsSSR, polls } = props;
   let { poll } = props;
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [pollResults, setPollResults] = useState(pollResultsSSR);
@@ -289,9 +279,6 @@ export default function ViewPoll(props: Props): JSX.Element {
                       <VoteOnPollButtons
                         pollName={poll.name}
                         pollId={poll.id}
-                        isActiveVoter={
-                          workshopActiveVoterId === session.data?.user.id
-                        }
                         hashedText={poll.hashedText}
                         link={poll.link}
                       />
@@ -384,7 +371,6 @@ export const getServerSideProps = async (
       }[];
     };
     polls: Poll[];
-    workshopActiveVoterId: string;
   };
 }> => {
   if (!context.params) {
@@ -395,22 +381,11 @@ export const getServerSideProps = async (
         workshops: [],
         pollResultsSSR: {},
         polls: [],
-        workshopActiveVoterId: '',
       },
     };
   }
 
   const { pollId } = context.params;
-
-  const session = await getServerSession(context.req, context.res, authOptions);
-
-  let workshopActiveVoterId = '';
-  if (session) {
-    const activeVoterId = await activeVoterDto(session.user.id);
-    if (activeVoterId) {
-      workshopActiveVoterId = activeVoterId;
-    }
-  }
 
   const poll = await pollDto(pollId);
   const representatives = await representativesDto();
@@ -425,7 +400,6 @@ export const getServerSideProps = async (
       workshops: workshops,
       pollResultsSSR: pollResultsSSR,
       polls: polls,
-      workshopActiveVoterId: workshopActiveVoterId,
     },
   };
 };


### PR DESCRIPTION
There was a bug that would occur when a delegate connected their wallet while on a specific poll page. It would always show that they are not the active voter.

This was related to the SSR being used for the poll page. It was not properly updating after the delegate connected their wallet. This PR changes it so that the active voter status is fetched client-side so that it will probably update when a delegate connects their wallet.