### PR TITLE
Add delegate name 64 byte check

### DIFF
--- a/src/lib/getStringBytes.ts
+++ b/src/lib/getStringBytes.ts
@@ -1,0 +1,9 @@
+/**
+ * Gets the byte size of a string
+ * @param str - The string to get the byte size of
+ * @returns Number of bytes
+ */
+export function getStringBytes(str: string): number {
+  const byteSize = new Blob([str]).size;
+  return byteSize;
+}

--- a/src/pages/api/updateUser.ts
+++ b/src/pages/api/updateUser.ts
@@ -7,6 +7,7 @@ import { getServerSession } from 'next-auth';
 
 import { checkIfCO } from '@/lib/checkIfCO';
 import { checkIfVoting } from '@/lib/checkIfVoting';
+import { getStringBytes } from '@/lib/getStringBytes';
 
 type Data = {
   userId: string;
@@ -66,10 +67,10 @@ export default async function updateUser(
         message: 'Name must be provided.',
       });
     }
-    if (name.length > 100) {
+    if (getStringBytes(name) > 64) {
       return res.status(400).json({
         userId: BigInt(-1).toString(),
-        message: 'Name must be less than 100 characters.',
+        message: 'Name must be less than 64 characters.',
       });
     }
     // validate email


### PR DESCRIPTION
A delegate's name is used as the key for their vote metadata in the on-chain TXs. A single string (including the key) cannot exceed 64 bytes or the metadata will be invalid. As a result, I have added a check that a delegate's name is less than 64 bytes when a CO attempts to edit the delegate's name.

I added the same check in the seed function which can be seen in [this commit](https://github.com/ClearContracts/voting-app-seed-db/pull/3/commits/2a138d0141056877a182ecd1668611014f27bb80).

These 2 checks should ensure that no name which exceeds 64 bytes makes it into the database.