### PR TITLE
Add in progress option to voting history table

### DIFF
--- a/src/components/representatives/votingHistoryTable.tsx
+++ b/src/components/representatives/votingHistoryTable.tsx
@@ -1,3 +1,4 @@
+import { pollPhases } from '@/constants/pollPhases';
 import DoDisturbRounded from '@mui/icons-material/DoDisturbRounded';
 import ThumbDownRounded from '@mui/icons-material/ThumbDownRounded';
 import ThumbUpRounded from '@mui/icons-material/ThumbUpRounded';
@@ -42,6 +43,7 @@ export function VotingHistoryTable(props: Props): JSX.Element {
         const userVoteData = votes.find(
           (vote) => vote.poll_id === params.row.id,
         );
+        const poll = polls.find((poll) => poll.id === params.row.id);
         const userVote = userVoteData?.vote;
         return (
           <Box
@@ -66,7 +68,13 @@ export function VotingHistoryTable(props: Props): JSX.Element {
             {userVote === 'abstain' && (
               <DoDisturbRounded data-testid={`abstain-${params.row.id}`} />
             )}
-            {!userVote && (
+            {poll?.status === pollPhases.pending ||
+              (poll?.status === pollPhases.voting && (
+                <Typography data-testid={`none-${params.row.id}`}>
+                  In Progress
+                </Typography>
+              ))}
+            {poll?.status === pollPhases.concluded && !userVote && (
               <Typography data-testid={`none-${params.row.id}`}>
                 None
               </Typography>


### PR DESCRIPTION
Previously, a user's voting history table would just show "None" for an actively voting poll even if they had already voted. I just accidentally spent some time troubleshooting this as I thought it was an error before I remembered we just display "None" for active polls.

To avoid any confusion from the delegates, I have added a "In Progress" option on the voting history table for in progress polls.

In the examples below, poll #2 is voting.

### Before
<img width="573" alt="Screenshot 2024-11-25 at 9 06 11 PM" src="https://github.com/user-attachments/assets/3299a1a8-7b8a-406e-af06-81a1a956df5d">

### After
<img width="565" alt="Screenshot 2024-11-25 at 9 05 46 PM" src="https://github.com/user-attachments/assets/97d5e2ee-2b75-4817-9574-80f9b6b9c506">

### None Vote
As you can see in the image below, "None" is still used for the case of a concluded poll that the user did not vote on.
<img width="565" alt="Screenshot 2024-11-25 at 9 08 26 PM" src="https://github.com/user-attachments/assets/8df4b345-c7c3-4d8a-a650-a69f51eb8658">

