### PR TITLE
include challenge in message to sign

### DIFF
--- a/src/lib/connectWallet.tsx
+++ b/src/lib/connectWallet.tsx
@@ -27,7 +27,8 @@ export async function connectWallet(
     const wallet = await connectWalletClarity(walletName);
     updateWallet(wallet);
     const timestamp = new Date().toLocaleString();
-    const message = `Sign this message to verify wallet ownership.\nTimestamp: ${timestamp}`;
+    const challenge = await getChallenge();
+    const message = `Sign this message to verify wallet ownership.\nTimestamp: ${timestamp}\nChallenge: ${challenge.challenge}`;
     const messageHex = Buffer.from(message).toString('hex');
 
     // @ts-expect-error getNetworkId exists
@@ -45,7 +46,6 @@ export async function connectWallet(
 
     // @ts-expect-error getNetworkId is actually a proper function
     const signature = await wallet.signData(stakeAddressHex, messageHex);
-    const challenge = await getChallenge();
 
     // Sign in is defined here pages/api/auth/[...nextauth].ts
     const signInResponse = await signIn('credentials', {

--- a/src/lib/signMessage.tsx
+++ b/src/lib/signMessage.tsx
@@ -38,7 +38,9 @@ export async function signMessage(
 
   const challenge = await getChallenge();
 
-  const messageHex = Buffer.from(message).toString('hex');
+  const messageWithChallenge = `${message}, Challenge: ${challenge.challenge}`;
+
+  const messageHex = Buffer.from(messageWithChallenge).toString('hex');
   // @ts-expect-error signData is actually a proper function
   const signature = await wallet.signData(stakeAddressHex, messageHex);
   if (!signature.signature) {
@@ -48,7 +50,7 @@ export async function signMessage(
     return false;
   } else {
     return {
-      signature: { signedMessage: signature, payload: message },
+      signature: { signedMessage: signature, payload: messageWithChallenge },
       challenge: challenge,
     };
   }

--- a/src/lib/verifyWallet.ts
+++ b/src/lib/verifyWallet.ts
@@ -66,8 +66,6 @@ export const verifyWallet = async (
     const payloadChallenge = signatureWords[signatureWords.length - 1];
     const challengeAsExpected = payloadChallenge == challenge;
 
-    console.log('challengeAsExpected', challengeAsExpected);
-
     // Some wallets may hash the payload before signing it (e.g. eternl). Some wallets may not hash the payload before signing it (e.g. Lace).
     // The above check is for the case where the payload is not hashed before signing.
     // If the payload does not match, then we hash the payload and compare the hash.

--- a/src/lib/verifyWallet.ts
+++ b/src/lib/verifyWallet.ts
@@ -61,6 +61,13 @@ export const verifyWallet = async (
     const isVerified = publicKey?.verify(receivedData, signature);
     let payloadAsExpected = utf8Payload == originalPayload;
 
+    // verify challenge is the same that was passed in, challenge is after :
+    const signatureWords = utf8Payload.split(' ');
+    const payloadChallenge = signatureWords[signatureWords.length - 1];
+    const challengeAsExpected = payloadChallenge == challenge;
+
+    console.log('challengeAsExpected', challengeAsExpected);
+
     // Some wallets may hash the payload before signing it (e.g. eternl). Some wallets may not hash the payload before signing it (e.g. Lace).
     // The above check is for the case where the payload is not hashed before signing.
     // If the payload does not match, then we hash the payload and compare the hash.
@@ -85,7 +92,8 @@ export const verifyWallet = async (
       payloadAsExpected = originalPayloadHashHex == decodedPayloadHashHex;
     }
 
-    const isAuthSuccess = isVerified && payloadAsExpected;
+    const isAuthSuccess =
+      isVerified && payloadAsExpected && challengeAsExpected;
 
     return isAuthSuccess === true;
   } catch (err) {


### PR DESCRIPTION
Messages are signed 2 times in the app:
1. to sign in
2. to cast a vote

We needed to include a unique challenge to not allow signatures to be reused in the app.

Now, the app generates the unique challenge before requesting a signature from the user wallet, and the challenge is included in the message that the user signs.

In the verifyWallet function, we get the challenge from the end of the signed message & confirm it matches this request.