### PR TITLE
adding default poll wording description field in poll page

### DIFF
--- a/src/pages/polls/[pollId]/index.tsx
+++ b/src/pages/polls/[pollId]/index.tsx
@@ -184,10 +184,21 @@ export default function ViewPoll(props: Props): JSX.Element {
             {poll ? (
               <Grid
                 size={{ xs: 12, lg: 6 }}
+                sx={{
+                  pr: {
+                    xs: 0,
+                    lg: 12,
+                  },
+                }}
                 display="flex"
                 flexDirection="column"
                 gap={3}
               >
+                <Typography>
+                  Shall the Cardano Constitution text, located at the link and
+                  with the hash as stated below, be approved for on-chain
+                  submission as a New Constitution governance action?
+                </Typography>
                 <Box>
                   <Button
                     variant="outlined"


### PR DESCRIPTION
Add default poll wording to poll page
<img width="788" alt="image" src="https://github.com/user-attachments/assets/466b2b24-83b6-4c8a-a93c-3c5b2cab9fad">
