### PR TITLE
Make poll name the default description

### DIFF
--- a/src/pages/polls/[pollId]/index.tsx
+++ b/src/pages/polls/[pollId]/index.tsx
@@ -161,24 +161,10 @@ export default function ViewPoll(props: Props): JSX.Element {
               Archived
             </Typography>
           )}
-          <Box
-            display="flex"
-            flexDirection="row"
-            gap={3}
-            justifyContent={{ xs: 'space-between', lg: 'flex-start' }}
-            alignItems="center"
-          >
-            <Typography variant="h1" fontWeight="bold">
-              {poll ? (
-                poll.name
-              ) : isPending ? (
-                <CircularProgress />
-              ) : (
-                'View Poll'
-              )}
-            </Typography>
-            {poll && <PollStatusChip status={poll.status} />}
-          </Box>
+          <Typography variant="h4" fontWeight="bold">
+            {poll ? poll.name : isPending ? <CircularProgress /> : 'View Poll'}
+          </Typography>
+          {poll && <PollStatusChip status={poll.status} />}
           <PollVoteCount pollId={poll?.id || ''} />
           <Grid container data-testid="poll-transactions">
             {poll ? (
@@ -194,11 +180,6 @@ export default function ViewPoll(props: Props): JSX.Element {
                 flexDirection="column"
                 gap={3}
               >
-                <Typography>
-                  Shall the Cardano Constitution text, located at the link and
-                  with the hash as stated below, be approved for on-chain
-                  submission as a New Constitution governance action?
-                </Typography>
                 <Box>
                   <Button
                     variant="outlined"

--- a/src/pages/polls/new.tsx
+++ b/src/pages/polls/new.tsx
@@ -14,7 +14,9 @@ interface Props {
 export default function NewPoll(props: Props): JSX.Element {
   const { polls } = props;
   useCheckAddressChange();
-  const [name, setName] = useState(`Poll #${polls.length + 1}`);
+  const [name, setName] = useState(
+    'Shall the Cardano Constitution text, located at the link and with the hash as stated below, be approved for on-chain submission as a New Constitution governance action?',
+  );
   const [constitutionText, setConstitutionText] = useState('');
   const [link, setLink] = useState('');
 
@@ -54,6 +56,8 @@ export default function NewPoll(props: Props): JSX.Element {
             label="Name"
             value={name}
             data-testid="poll-name-input"
+            multiline
+            rows={2} // Number of visible rows
           />
           <TextField
             variant="outlined"


### PR DESCRIPTION
The default description now prepopulates in the "name" input field so it can be changed as needed. I moved the status pill to below the poll name since the poll name is now so large.

<img width="1252" alt="Screenshot 2024-11-29 at 4 14 48 PM" src="https://github.com/user-attachments/assets/ca2926e6-fe89-4436-905c-6e30f47e528b">

Desktop:
<img width="1238" alt="Screenshot 2024-11-29 at 4 20 11 PM" src="https://github.com/user-attachments/assets/88243107-cf5c-4596-a2a8-1ff8f472d368">

Mobile:
<img width="370" alt="Screenshot 2024-11-29 at 4 20 22 PM" src="https://github.com/user-attachments/assets/89642e7b-f960-490f-9e7b-c16e505f7156">

I conducted a test with 63 mock votes and uploaded all of the votes on-chain which can be seen [here](https://preview.cardanoscan.io/transaction/56bd4a4874bf80a9613b6b115012cdf12ad7c9f3eb37013665a8054d33475e71?tab=metadata). I did the test on preview as Intersect did not want a poll with the default description on mainnet other than the official votes.