### PR TITLE
Add support for Yoroi

### DIFF
--- a/src/components/representatives/mobileRepresentativesTable.tsx
+++ b/src/components/representatives/mobileRepresentativesTable.tsx
@@ -1,12 +1,8 @@
 import { useMemo } from 'react';
-import Link from 'next/link';
 import { Box, useTheme } from '@mui/material';
 import Typography from '@mui/material/Typography';
-import { DataGrid, GridColDef } from '@mui/x-data-grid';
 
 import type { User, Workshop } from '@/types';
-import { paths } from '@/paths';
-import { abbreviateName } from '@/lib/helpers/abbreviateName';
 import { MobileRepresentativeCard } from '@/components/representatives/mobileRepresentativeCard';
 
 interface Props {
@@ -28,7 +24,12 @@ export function MobileRepresentativesTable(props: Props): JSX.Element {
   const representativesList = useMemo(() => {
     return representatives.map((rep) => {
       return (
-        <MobileRepresentativeCard representative={rep} workshops={workshops} />
+        <Box key={rep.id}>
+          <MobileRepresentativeCard
+            representative={rep}
+            workshops={workshops}
+          />
+        </Box>
       );
     });
   }, [representatives]);

--- a/src/hooks/useCheckAddressChange.tsx
+++ b/src/hooks/useCheckAddressChange.tsx
@@ -27,7 +27,7 @@ export function useCheckAddressChange(): void {
       async function handler(): Promise<void> {
         if (session && wallet) {
           const hasChanged = await checkAddressChange(
-            wallet,
+            session.user.walletName,
             session.user.stakeAddress,
           );
           if (hasChanged) {

--- a/src/lib/checkAddressChange.tsx
+++ b/src/lib/checkAddressChange.tsx
@@ -1,4 +1,3 @@
-import type { Wallet } from '@claritydao/clarity-backend';
 import { connectWallet } from '@claritydao/clarity-backend';
 import * as Sentry from '@sentry/nextjs';
 

--- a/src/lib/checkAddressChange.tsx
+++ b/src/lib/checkAddressChange.tsx
@@ -1,19 +1,23 @@
 import type { Wallet } from '@claritydao/clarity-backend';
+import { connectWallet } from '@claritydao/clarity-backend';
 import * as Sentry from '@sentry/nextjs';
 
 import { deriveStakeAddressFromRewardAddress } from '@/lib/deriveStakeAddressFromRewardAddress';
 
 /**
  * This function checks if the user has changed their wallet since connecting
- * @param wallet - Wallet object from clarity-backend
+ * @param walletName - Name of the wallet to connect (ex: eternl, nami, etc)
  * @param currentStakeAddress - Current stake address of the user from the session
  * @returns boolean - True if the user has changed their wallet, false otherwise
  */
 export async function checkAddressChange(
-  wallet: Wallet,
+  walletName: string,
   currentStakeAddress: string,
 ): Promise<boolean> {
   try {
+    // NOTE: After the initial connection, Yoroi returns a different wallet object than the other wallets.
+    // This is why we must connect to the wallet each time we want to check the correct stake address.
+    const wallet = await connectWallet(walletName);
     const { stakeAddress } = await deriveStakeAddressFromRewardAddress(wallet);
 
     if (currentStakeAddress !== stakeAddress) {


### PR DESCRIPTION
This PR solves issue #196 related to Yoroi users getting signed out.

Yoroi has a different implementation for the wallet object than the other wallets do. On the first connection, it will match the typical wallet object structure that we expect. However, after that it will return a different wallet object. That is why people with Yoroi could sign in, but then on the subsequent checks of their current wallet account it would error out as the expected `getRewardAddresses` function did not exist. This error would cause them to get logged out.

Now in the `useCheckAddressChange` hook, we reconnect to the wallet on each check to ensure we consistently get the same wallet object we expect.

I opened a poll and was able to sign in and vote with Yoroi no problem. My Eternl and Lace wallets also continue to work as expected.

I also had some cleanup for `mobileRepresentativesTable`.

